### PR TITLE
make textarea scrollable

### DIFF
--- a/lib/MentionsInput.js
+++ b/lib/MentionsInput.js
@@ -261,7 +261,8 @@ var _initialiseProps = function _initialiseProps() {
       onKeyDown: _this2.handleKeyDown,
       onBlur: _this2.handleBlur,
       onCompositionStart: _this2.handleCompositionStart,
-      onCompositionEnd: _this2.handleCompositionEnd
+      onCompositionEnd: _this2.handleCompositionEnd,
+      onScroll: _this2.updateHighlighterScroll
     });
   };
 
@@ -611,6 +612,8 @@ var _initialiseProps = function _initialiseProps() {
     var input = _this2.refs.input;
     var highlighter = _reactDom2.default.findDOMNode(_this2.refs.highlighter);
     highlighter.scrollLeft = input.scrollLeft;
+    highlighter.scrollTop = input.scrollTop;
+    highlighter.height = input.height;
   };
 
   this.handleCompositionStart = function () {

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -136,6 +136,7 @@ class MentionsInput extends React.Component {
         onBlur: this.handleBlur,
         onCompositionStart: this.handleCompositionStart,
         onCompositionEnd: this.handleCompositionEnd,
+        onScroll: this.updateHighlighterScroll
       })
     };
   };
@@ -483,6 +484,8 @@ class MentionsInput extends React.Component {
     const input = this.refs.input;
     const highlighter = ReactDOM.findDOMNode(this.refs.highlighter);
     highlighter.scrollLeft = input.scrollLeft;
+    highlighter.scrollTop = input.scrollTop;
+    highlighter.height = input.height;
   };
 
   handleCompositionStart = () => {


### PR DESCRIPTION
mention highlights will now correctly track when scrolling textarea.
copied from https://github.com/signavio/react-mentions/pull/227/files in main fork of react-mentions